### PR TITLE
Switch STT queue to RabbitMQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
 # Automation-pipeline-STT
+
+Kerangka proyek ini menyediakan dua alur ETL untuk memproses file audio format GSM menjadi WAV
+berdasarkan data yang tersimpan di Postgres.
+
+## Arsitektur
+
+- **Batch ETL** (`scripts/run_batch.py`)
+  - Mengambil data dari database setiap jam 22.00 hingga 09.00 menggunakan APScheduler.
+  - Mengambil daftar `ticket_id` dan `file_path` yang belum diproses.
+  - Mencari file `.gsm` di server fisik berdasarkan `file_path` dan mengonversinya menjadi `.wav`
+    dengan nama file `{{ticket_id}}.wav`.
+  - Menandai tiket yang berhasil diproses pada database.
+- **Near real-time ETL** (`scripts/run_webhook.py`)
+  - Menyediakan endpoint FastAPI (`POST /webhook`) yang bisa dipanggil melalui webhook ketika ada
+    data baru.
+  - Payload harus berisi `ticket_id` dan `file_path`; proses konversi akan dilakukan segera.
+  - Setelah file `.wav` terbentuk, tiket akan dipublikasikan ke antrean RabbitMQ untuk dikirim ke
+    layanan Speech-to-Text (STT) melalui HTTP API.
+
+## Persiapan Lingkungan
+
+1. Pastikan Python 3.10+ tersedia.
+2. Instal dependensi proyek:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Opsional: jalankan RabbitMQ beserta Management UI untuk memantau antrean dengan Docker Compose:
+
+   ```bash
+   docker compose -f docker-compose.rabbitmq.yml up -d
+   ```
+
+   Layanan akan tersedia di `amqp://stt:stt_password@localhost:5672/` dan UI dapat diakses melalui
+   <http://localhost:15672> dengan kredensial `stt` / `stt_password`. Anda dapat menyesuaikan
+   pengguna dan kata sandi pada berkas Compose sesuai kebutuhan dan memperbarui variabel
+   lingkungan aplikasi.
+
+4. Setel variabel lingkungan berikut:
+
+   - `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DBNAME`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
+   - `ETL_SOURCE_ROOT` : direktori root tempat file `.gsm` disimpan.
+   - `ETL_OUTPUT_ROOT` : direktori tujuan file `.wav`.
+   - Opsional: `ETL_ARCHIVE_ROOT` untuk memindahkan file sumber setelah diproses,
+     `ETL_BATCH_SIZE` untuk mengatur jumlah data sekali proses,
+     `ETL_FFMPEG_BINARY` jika lokasi `ffmpeg` berbeda.
+   - Untuk integrasi STT near real-time:
+     - `STT_API_URL` : endpoint yang menerima permintaan transkripsi.
+     - Opsional: `STT_API_KEY` dan `STT_API_KEY_HEADER` bila endpoint memerlukan otorisasi,
+       `STT_TIMEOUT`, `STT_MAX_RETRIES`, `STT_RETRY_BACKOFF` untuk mengatur perilaku retry.
+   - Untuk koneksi antrean RabbitMQ (sesuaikan dengan konfigurasi Docker Compose di atas bila digunakan):
+      - `RABBITMQ_HOST` : alamat server RabbitMQ.
+      - Opsional: `RABBITMQ_PORT`, `RABBITMQ_USERNAME`, `RABBITMQ_PASSWORD`, `RABBITMQ_VHOST`,
+        `RABBITMQ_QUEUE`, `RABBITMQ_PREFETCH_COUNT`, `RABBITMQ_RECONNECT_DELAY`,
+        `RABBITMQ_PUBLISH_RETRIES`, `RABBITMQ_REQUEUE_ON_FAIL`.
+
+## Menjalankan Batch ETL
+
+```bash
+python scripts/run_batch.py
+```
+
+Scheduler akan berjalan blocking; hentikan dengan `Ctrl+C`.
+
+## Menjalankan Webhook Near Real-Time
+
+```bash
+python scripts/run_webhook.py
+```
+
+Secara bawaan server akan berjalan pada `0.0.0.0:8000`. Anda dapat menyesuaikannya dengan
+variabel `WEBHOOK_HOST` dan `WEBHOOK_PORT`.
+
+Ketika webhook menerima data baru, proses ETL akan langsung berjalan dan hasil `.wav` akan
+dipublikasikan ke antrean RabbitMQ. Worker latar belakang akan mengonsumsi antrean tersebut dan
+mengirimkan file ke API `STT_API_URL` dengan retry sesuai konfigurasi sehingga proses transkripsi
+dapat berlangsung tanpa menahan request webhook.
+
+Contoh payload webhook:
+
+```json
+{
+  "ticket_id": "TICKET-001",
+  "file_path": "2024/05/recording-001.gsm"
+}
+```
+
+## Struktur Modul
+
+- `datachain_etl.config` : pembacaan konfigurasi dari environment.
+- `datachain_etl.db` : utilitas koneksi dan query Postgres.
+- `datachain_etl.file_system` : pencarian dan penanganan file sumber.
+- `datachain_etl.audio_conversion` : konversi audio menggunakan `ffmpeg`.
+- `datachain_etl.etl_core` : logika utama ETL.
+- `datachain_etl.scheduler` : penjadwalan batch job.
+- `datachain_etl.webhook` : aplikasi FastAPI untuk webhook near real-time.
+- `datachain_etl.stt_queue` : worker antrean untuk mengirim file hasil ETL ke layanan STT.
+- `datachain_etl.logging_config` : konfigurasi logging standar.
+
+## Catatan
+
+Konversi `.gsm` ke `.wav` mengandalkan `ffmpeg`. Pastikan binari tersebut tersedia pada server.

--- a/docker-compose.rabbitmq.yml
+++ b/docker-compose.rabbitmq.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: rabbitmq-stt
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: stt
+      RABBITMQ_DEFAULT_PASS: stt_password
+      RABBITMQ_DEFAULT_VHOST: "/"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  rabbitmq-data:
+    driver: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "datachain-etl"
+version = "0.1.0"
+description = "ETL pipelines for GSM audio ingestion and conversion"
+authors = [
+    {name = "Automation Pipeline Team"}
+]
+requires-python = ">=3.10"
+dependencies = [
+    "psycopg[binary]>=3.1",
+    "fastapi>=0.110",
+    "uvicorn>=0.23",
+    "apscheduler>=3.10",
+    "pydantic>=2.6",
+    "requests>=2.31",
+    "pika>=1.3"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0"
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"

--- a/scripts/run_batch.py
+++ b/scripts/run_batch.py
@@ -1,0 +1,24 @@
+"""Entrypoint for the nightly batch ETL scheduler."""
+
+from __future__ import annotations
+
+from datachain_etl.config import DatabaseConfig, ETLConfig
+from datachain_etl.etl_core import ETLPipeline
+from datachain_etl.logging_config import configure_logging
+from datachain_etl.scheduler import BatchETLScheduler
+
+
+def main() -> None:
+    configure_logging()
+    db_config = DatabaseConfig.from_env()
+    etl_config = ETLConfig.from_env()
+    pipeline = ETLPipeline(db_config, etl_config)
+    scheduler = BatchETLScheduler(pipeline)
+    try:
+        scheduler.start()
+    except KeyboardInterrupt:
+        scheduler.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_webhook.py
+++ b/scripts/run_webhook.py
@@ -1,0 +1,52 @@
+"""Entrypoint for the webhook-based near real-time ETL service."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import uvicorn
+
+from datachain_etl.config import DatabaseConfig, ETLConfig, RabbitMQConfig, STTConfig
+from datachain_etl.etl_core import ETLPipeline
+from datachain_etl.logging_config import configure_logging
+from datachain_etl.stt_queue import STTQueue
+from datachain_etl.webhook import create_app
+
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    configure_logging()
+    db_config = DatabaseConfig.from_env()
+    etl_config = ETLConfig.from_env()
+    pipeline = ETLPipeline(db_config, etl_config)
+
+    stt_config = STTConfig.from_env()
+    rabbitmq_config = RabbitMQConfig.from_env(require=False)
+    stt_queue: STTQueue | None = None
+    if stt_config is None:
+        logger.warning(
+            "STT_API_URL is not configured. STT queue will be disabled for webhook ingestion."
+        )
+    elif rabbitmq_config is None:
+        logger.warning(
+            "RabbitMQ is not configured. STT queue will be disabled for webhook ingestion."
+        )
+    else:
+        stt_queue = STTQueue(stt_config, rabbitmq_config)
+
+    app = create_app(pipeline, stt_queue=stt_queue)
+
+    host = os.getenv("WEBHOOK_HOST", "0.0.0.0")
+    port = int(os.getenv("WEBHOOK_PORT", "8000"))
+    try:
+        uvicorn.run(app, host=host, port=port)
+    finally:
+        if stt_queue is not None:
+            stt_queue.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datachain_etl/__init__.py
+++ b/src/datachain_etl/__init__.py
@@ -1,0 +1,14 @@
+"""Top-level package for the Datachain ETL service."""
+
+from .config import DatabaseConfig, ETLConfig, RabbitMQConfig, STTConfig
+from .etl_core import ETLPipeline
+from .stt_queue import STTQueue
+
+__all__ = [
+    "DatabaseConfig",
+    "ETLConfig",
+    "RabbitMQConfig",
+    "STTConfig",
+    "ETLPipeline",
+    "STTQueue",
+]

--- a/src/datachain_etl/audio_conversion.py
+++ b/src/datachain_etl/audio_conversion.py
@@ -1,0 +1,39 @@
+"""Audio conversion helpers leveraging ffmpeg."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from .file_system import ensure_directory
+
+
+class AudioConversionError(RuntimeError):
+    """Raised when ffmpeg fails to convert the GSM file."""
+
+
+def convert_gsm_to_wav(
+    source_path: Path,
+    destination_path: Path,
+    *,
+    ffmpeg_binary: str = "ffmpeg",
+) -> None:
+    """Convert a GSM audio file into a WAV file using ffmpeg."""
+
+    ensure_directory(destination_path)
+    command = [
+        ffmpeg_binary,
+        "-y",  # overwrite existing files
+        "-i",
+        str(source_path),
+        "-ac",
+        "1",
+        "-ar",
+        "8000",
+        str(destination_path),
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise AudioConversionError(
+            "ffmpeg failed to convert %s to WAV: %s" % (source_path, result.stderr.strip())
+        )

--- a/src/datachain_etl/config.py
+++ b/src/datachain_etl/config.py
@@ -1,0 +1,226 @@
+"""Configuration models for the Datachain ETL service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Optional
+
+import pika
+
+DEFAULT_FILE_QUERY = (
+    """
+    SELECT ticket_id, file_path
+    FROM audio_jobs
+    WHERE processed_at IS NULL
+    ORDER BY created_at
+    LIMIT %(batch_size)s
+    """
+    .strip()
+)
+
+
+@dataclass(slots=True)
+class DatabaseConfig:
+    """Connection details for the Postgres database."""
+
+    host: str
+    port: int
+    dbname: str
+    user: str
+    password: str
+    connect_timeout: int = 10
+
+    @classmethod
+    def from_env(cls, prefix: str = "POSTGRES_") -> "DatabaseConfig":
+        """Instantiate the configuration from environment variables.
+
+        Expected environment variables include ``{prefix}HOST``, ``{prefix}PORT``,
+        ``{prefix}DBNAME``, ``{prefix}USER`` and ``{prefix}PASSWORD``.
+        """
+
+        port_str = os.getenv(f"{prefix}PORT", "5432")
+        port = int(port_str)
+        missing = [
+            key
+            for key in ("HOST", "DBNAME", "USER", "PASSWORD")
+            if not os.getenv(f"{prefix}{key}")
+        ]
+        if missing:
+            raise RuntimeError(
+                "Missing required database environment variables: "
+                + ", ".join(f"{prefix}{key}" for key in missing)
+            )
+        return cls(
+            host=os.environ[f"{prefix}HOST"],
+            port=port,
+            dbname=os.environ[f"{prefix}DBNAME"],
+            user=os.environ[f"{prefix}USER"],
+            password=os.environ[f"{prefix}PASSWORD"],
+        )
+
+
+@dataclass(slots=True)
+class ETLConfig:
+    """Runtime configuration for the ETL pipeline."""
+
+    source_root: Path
+    output_root: Path
+    batch_size: int = 500
+    ffmpeg_binary: str = "ffmpeg"
+    file_query: str = DEFAULT_FILE_QUERY
+    archive_root: Optional[Path] = None
+
+    @classmethod
+    def from_env(cls, prefix: str = "ETL_") -> "ETLConfig":
+        """Instantiate the ETL configuration from environment variables."""
+
+        source_root = os.getenv(f"{prefix}SOURCE_ROOT")
+        output_root = os.getenv(f"{prefix}OUTPUT_ROOT")
+        if not source_root or not output_root:
+            raise RuntimeError(
+                "Both ETL_SOURCE_ROOT and ETL_OUTPUT_ROOT environment variables must be set."
+            )
+        archive_root = os.getenv(f"{prefix}ARCHIVE_ROOT")
+        batch_size = int(os.getenv(f"{prefix}BATCH_SIZE", "500"))
+        ffmpeg_binary = os.getenv(f"{prefix}FFMPEG_BINARY", "ffmpeg")
+        file_query = os.getenv(f"{prefix}FILE_QUERY", DEFAULT_FILE_QUERY)
+        return cls(
+            source_root=Path(source_root),
+            output_root=Path(output_root),
+            batch_size=batch_size,
+            ffmpeg_binary=ffmpeg_binary,
+            file_query=file_query,
+            archive_root=Path(archive_root) if archive_root else None,
+        )
+
+    def ensure_directories(self) -> None:
+        """Create the directories used by the ETL process if needed."""
+
+        self.source_root.mkdir(parents=True, exist_ok=True)
+        self.output_root.mkdir(parents=True, exist_ok=True)
+        if self.archive_root:
+            self.archive_root.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(slots=True)
+class STTConfig:
+    """Configuration for communicating with the STT API service."""
+
+    api_url: str
+    api_key: Optional[str] = None
+    api_key_header: str = "Authorization"
+    timeout: int = 30
+    max_retries: int = 3
+    retry_backoff: float = 2.0
+
+    @classmethod
+    def from_env(
+        cls,
+        prefix: str = "STT_",
+        *,
+        require: bool = False,
+    ) -> Optional["STTConfig"]:
+        """Instantiate the STT configuration from environment variables."""
+
+        api_url = os.getenv(f"{prefix}API_URL")
+        if not api_url:
+            if require:
+                raise RuntimeError("STT_API_URL environment variable must be provided")
+            return None
+
+        api_key = os.getenv(f"{prefix}API_KEY")
+        api_key_header = os.getenv(f"{prefix}API_KEY_HEADER", "Authorization")
+        timeout = int(os.getenv(f"{prefix}TIMEOUT", "30"))
+        max_retries = int(os.getenv(f"{prefix}MAX_RETRIES", "3"))
+        retry_backoff = float(os.getenv(f"{prefix}RETRY_BACKOFF", "2.0"))
+
+        return cls(
+            api_url=api_url,
+            api_key=api_key,
+            api_key_header=api_key_header,
+            timeout=timeout,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+        )
+
+    def build_headers(self) -> dict[str, str]:
+        """Construct request headers for STT API calls."""
+
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers[self.api_key_header] = self.api_key
+        return headers
+
+
+@dataclass(slots=True)
+class RabbitMQConfig:
+    """Connection information for RabbitMQ used by the STT queue."""
+
+    host: str
+    port: int = 5672
+    username: Optional[str] = None
+    password: Optional[str] = None
+    virtual_host: str = "/"
+    queue_name: str = "stt_tasks"
+    prefetch_count: int = 1
+    reconnect_delay: float = 5.0
+    requeue_on_fail: bool = False
+    publish_retries: int = 3
+
+    @classmethod
+    def from_env(
+        cls,
+        prefix: str = "RABBITMQ_",
+        *,
+        require: bool = True,
+    ) -> Optional["RabbitMQConfig"]:
+        """Instantiate the RabbitMQ configuration from environment variables."""
+
+        host = os.getenv(f"{prefix}HOST")
+        if not host:
+            if require:
+                raise RuntimeError("RABBITMQ_HOST environment variable must be provided")
+            return None
+
+        port = int(os.getenv(f"{prefix}PORT", "5672"))
+        username = os.getenv(f"{prefix}USERNAME")
+        password = os.getenv(f"{prefix}PASSWORD")
+        virtual_host = os.getenv(f"{prefix}VHOST", "/")
+        queue_name = os.getenv(f"{prefix}QUEUE", "stt_tasks")
+        prefetch_count = int(os.getenv(f"{prefix}PREFETCH_COUNT", "1"))
+        reconnect_delay = float(os.getenv(f"{prefix}RECONNECT_DELAY", "5.0"))
+        publish_retries = int(os.getenv(f"{prefix}PUBLISH_RETRIES", "3"))
+        requeue_on_fail = os.getenv(f"{prefix}REQUEUE_ON_FAIL", "false").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+        return cls(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            virtual_host=virtual_host,
+            queue_name=queue_name,
+            prefetch_count=prefetch_count,
+            reconnect_delay=reconnect_delay,
+            requeue_on_fail=requeue_on_fail,
+            publish_retries=publish_retries,
+        )
+
+    def connection_parameters(self) -> pika.ConnectionParameters:
+        """Construct a pika connection parameter object."""
+
+        credentials = None
+        if self.username:
+            credentials = pika.PlainCredentials(self.username, self.password or "")
+        return pika.ConnectionParameters(
+            host=self.host,
+            port=self.port,
+            virtual_host=self.virtual_host,
+            credentials=credentials,
+        )

--- a/src/datachain_etl/db.py
+++ b/src/datachain_etl/db.py
@@ -1,0 +1,65 @@
+"""Database utilities for interacting with Postgres."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator, Iterable, List, Mapping
+
+import psycopg
+from psycopg.rows import dict_row
+
+from .config import DatabaseConfig
+
+Record = Mapping[str, object]
+
+
+@contextmanager
+def get_connection(config: DatabaseConfig) -> Generator[psycopg.Connection, None, None]:
+    """Yield a Postgres connection configured via :class:`DatabaseConfig`."""
+
+    conn = psycopg.connect(
+        host=config.host,
+        port=config.port,
+        dbname=config.dbname,
+        user=config.user,
+        password=config.password,
+        connect_timeout=config.connect_timeout,
+        row_factory=dict_row,
+    )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def fetch_pending_records(
+    conn: psycopg.Connection, query: str, batch_size: int
+) -> List[Record]:
+    """Retrieve records that need to be processed by the ETL job."""
+
+    with conn.cursor() as cur:
+        cur.execute(query, {"batch_size": batch_size})
+        rows = cur.fetchall()
+    return rows
+
+
+def mark_records_processed(
+    conn: psycopg.Connection,
+    ticket_ids: Iterable[str],
+    *,
+    table: str = "audio_jobs",
+) -> None:
+    """Mark the provided ticket IDs as processed."""
+
+    if not ticket_ids:
+        return
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE {table}
+            SET processed_at = NOW()
+            WHERE ticket_id = ANY(%(ticket_ids)s)
+            """,
+            {"ticket_ids": list(ticket_ids)},
+        )
+    conn.commit()

--- a/src/datachain_etl/etl_core.py
+++ b/src/datachain_etl/etl_core.py
@@ -1,0 +1,112 @@
+"""Core ETL pipeline orchestration."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from .audio_conversion import AudioConversionError, convert_gsm_to_wav
+from .config import DatabaseConfig, ETLConfig
+from .db import fetch_pending_records, get_connection, mark_records_processed
+from .file_system import (
+    MissingSourceFileError,
+    archive_source_file,
+    resolve_file_path,
+)
+
+Record = Mapping[str, object]
+
+
+class ETLPipeline:
+    """Encapsulates the GSM to WAV ETL workflow."""
+
+    def __init__(
+        self,
+        db_config: DatabaseConfig,
+        etl_config: ETLConfig,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.db_config = db_config
+        self.etl_config = etl_config
+        self.logger = logger or logging.getLogger(__name__)
+
+    def run_batch(self) -> None:
+        """Process a batch of records as configured."""
+
+        self.logger.info("Starting batch ETL run")
+        self.etl_config.ensure_directories()
+        with get_connection(self.db_config) as conn:
+            records = fetch_pending_records(
+                conn, self.etl_config.file_query, self.etl_config.batch_size
+            )
+            self.logger.info("Fetched %d pending records", len(records))
+            processed_ticket_ids = self._process_records(records)
+            mark_records_processed(conn, processed_ticket_ids)
+            self.logger.info(
+                "Batch ETL completed for %d records", len(processed_ticket_ids)
+            )
+
+    def process_single(self, ticket_id: str, file_path: str) -> Path:
+        """Process a single record, used for near real-time ingestion."""
+
+        record = {"ticket_id": ticket_id, "file_path": file_path}
+        self.etl_config.ensure_directories()
+        with get_connection(self.db_config) as conn:
+            processed = self._process_records([record])
+            if not processed:
+                raise RuntimeError(
+                    f"Processing failed for ticket_id={ticket_id} file_path={file_path}"
+                )
+            mark_records_processed(conn, processed)
+        return self._determine_destination_path(ticket_id)
+
+    def _process_records(self, records: Sequence[Record]) -> Iterable[str]:
+        """Process records and yield ticket IDs that completed successfully."""
+
+        successful: list[str] = []
+        for record in records:
+            ticket_id_raw = record.get("ticket_id")
+            file_path_raw = record.get("file_path")
+            if not ticket_id_raw or not file_path_raw:
+                self.logger.error("Skipping record with incomplete data: %s", record)
+                continue
+
+            ticket_id = str(ticket_id_raw)
+            file_path = str(file_path_raw)
+            try:
+                source_path = resolve_file_path(self.etl_config.source_root, file_path)
+                destination = self._determine_destination_path(ticket_id)
+                convert_gsm_to_wav(
+                    source_path,
+                    destination,
+                    ffmpeg_binary=self.etl_config.ffmpeg_binary,
+                )
+                archive_source_file(source_path, self.etl_config.archive_root)
+                successful.append(ticket_id)
+                self.logger.info(
+                    "Converted ticket_id=%s from %s to %s",
+                    ticket_id,
+                    source_path,
+                    destination,
+                )
+            except MissingSourceFileError as exc:
+                self.logger.error("Source file missing for ticket_id=%s: %s", ticket_id, exc)
+            except AudioConversionError as exc:
+                self.logger.error(
+                    "Audio conversion failed for ticket_id=%s: %s", ticket_id, exc
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.logger.exception(
+                    "Unexpected error while processing ticket_id=%s: %s",
+                    ticket_id,
+                    exc,
+                )
+        return successful
+
+    def _determine_destination_path(self, ticket_id: str) -> Path:
+        """Compute the destination path for the converted WAV file."""
+
+        filename = f"{ticket_id}.wav"
+        return self.etl_config.output_root / filename

--- a/src/datachain_etl/file_system.py
+++ b/src/datachain_etl/file_system.py
@@ -1,0 +1,40 @@
+"""Helpers for working with the filesystem."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+class MissingSourceFileError(FileNotFoundError):
+    """Raised when the expected source GSM file cannot be located."""
+
+
+def resolve_file_path(source_root: Path, file_path: str) -> Path:
+    """Resolve a database ``file_path`` into an absolute path on disk."""
+
+    candidate = source_root.joinpath(file_path.lstrip("/"))
+    if candidate.exists():
+        return candidate
+
+    gsm_candidate = candidate.with_suffix(".gsm")
+    if gsm_candidate.exists():
+        return gsm_candidate
+
+    raise MissingSourceFileError(f"Unable to locate GSM file for {file_path}")
+
+
+def ensure_directory(path: Path) -> None:
+    """Create the parent directory for ``path`` if necessary."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def archive_source_file(source_path: Path, archive_root: Optional[Path]) -> None:
+    """Move the processed file into an archive directory if configured."""
+
+    if not archive_root:
+        return
+    archive_path = archive_root / source_path.name
+    ensure_directory(archive_path)
+    source_path.rename(archive_path)

--- a/src/datachain_etl/logging_config.py
+++ b/src/datachain_etl/logging_config.py
@@ -1,0 +1,19 @@
+"""Utilities for configuring service logging."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional
+
+
+def configure_logging(level: int = logging.INFO, *, log_format: Optional[str] = None) -> None:
+    """Configure global logging defaults for the ETL service."""
+
+    logging.basicConfig(
+        level=level,
+        format=log_format
+        or "%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )

--- a/src/datachain_etl/scheduler.py
+++ b/src/datachain_etl/scheduler.py
@@ -1,0 +1,47 @@
+"""Scheduling utilities for the ETL pipelines."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from .etl_core import ETLPipeline
+
+logger = logging.getLogger(__name__)
+
+
+class BatchETLScheduler:
+    """Schedule the batch ETL job to run nightly between 22:00 and 09:00."""
+
+    def __init__(
+        self,
+        pipeline: ETLPipeline,
+        *,
+        timezone: str = "Asia/Jakarta",
+        scheduler: Optional[BlockingScheduler] = None,
+    ) -> None:
+        self.pipeline = pipeline
+        self.scheduler = scheduler or BlockingScheduler(timezone=timezone)
+
+    def start(self) -> None:
+        """Start the blocking scheduler."""
+
+        hours = [22, 23] + list(range(0, 10))
+        hour_expr = ",".join(str(hour) for hour in hours)
+        trigger = CronTrigger(hour=hour_expr, minute=0)
+        self.scheduler.add_job(self.pipeline.run_batch, trigger, id="nightly-batch")
+        logger.info(
+            "Scheduled batch ETL job for hours=%s timezone=%s",
+            hour_expr,
+            self.scheduler.timezone,
+        )
+        self.scheduler.start()
+
+    def shutdown(self) -> None:
+        """Stop the scheduler."""
+
+        if self.scheduler.running:
+            self.scheduler.shutdown(wait=False)

--- a/src/datachain_etl/stt_queue.py
+++ b/src/datachain_etl/stt_queue.py
@@ -1,0 +1,310 @@
+"""Queue and worker utilities for sending WAV files to the STT API via RabbitMQ."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pika
+import requests
+from pika.adapters.blocking_connection import BlockingChannel
+from pika.exceptions import AMQPConnectionError
+from requests import RequestException
+
+from .config import RabbitMQConfig, STTConfig
+
+
+@dataclass(slots=True)
+class STTTask:
+    """Representation of a transcription request."""
+
+    ticket_id: str
+    wav_path: Path
+
+    def to_payload(self) -> bytes:
+        """Serialise the task into a JSON payload."""
+
+        payload = {"ticket_id": self.ticket_id, "wav_path": str(self.wav_path)}
+        return json.dumps(payload).encode("utf-8")
+
+    @classmethod
+    def from_payload(cls, payload: bytes) -> "STTTask":
+        """Reconstruct a task instance from a JSON payload."""
+
+        data = json.loads(payload.decode("utf-8"))
+        ticket_id = data["ticket_id"]
+        wav_path = Path(data["wav_path"])
+        return cls(ticket_id=ticket_id, wav_path=wav_path)
+
+
+class STTQueue:
+    """A RabbitMQ-backed background worker that sends WAV files to the STT API."""
+
+    def __init__(
+        self,
+        stt_config: STTConfig,
+        rabbitmq_config: RabbitMQConfig,
+        *,
+        session: Optional[requests.Session] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self.stt_config = stt_config
+        self.rabbitmq_config = rabbitmq_config
+        self.session = session or requests.Session()
+        self.logger = logger or logging.getLogger(__name__)
+        self._connection_params = self.rabbitmq_config.connection_parameters()
+        self._consumer_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        """Start the queue worker if it is not already running."""
+
+        if self._consumer_thread and self._consumer_thread.is_alive():
+            return
+        self._ensure_queue()
+        self._stop_event.clear()
+        self._consumer_thread = threading.Thread(
+            target=self._run,
+            name="stt-rabbitmq-worker",
+            daemon=True,
+        )
+        self._consumer_thread.start()
+        self.logger.info("STT queue worker started")
+
+    def stop(self) -> None:
+        """Signal the worker to stop and wait briefly for shutdown."""
+
+        if not self._consumer_thread:
+            return
+        self._stop_event.set()
+        self._consumer_thread.join(timeout=5)
+        if self._consumer_thread.is_alive():
+            self.logger.warning("STT queue worker did not shut down cleanly")
+        else:
+            self.logger.info("STT queue worker stopped")
+            self._stop_event.clear()
+        self._consumer_thread = None
+
+    def enqueue(self, ticket_id: str, wav_path: Path) -> None:
+        """Publish a new task to RabbitMQ for processing."""
+
+        if not isinstance(wav_path, Path):
+            wav_path = Path(wav_path)
+        if not wav_path.exists():
+            self.logger.error(
+                "Cannot enqueue STT task for ticket_id=%s; file missing at %s",
+                ticket_id,
+                wav_path,
+            )
+            return
+        self.start()
+        task = STTTask(ticket_id=ticket_id, wav_path=wav_path)
+        self._publish_task(task)
+        self.logger.debug(
+            "Queued STT transcription request for ticket_id=%s at %s",
+            ticket_id,
+            wav_path,
+        )
+
+    def _ensure_queue(self) -> None:
+        """Ensure that the RabbitMQ queue exists."""
+
+        connection: Optional[pika.BlockingConnection] = None
+        channel: Optional[BlockingChannel] = None
+        try:
+            connection = pika.BlockingConnection(self._connection_params)
+            channel = connection.channel()
+            channel.queue_declare(queue=self.rabbitmq_config.queue_name, durable=True)
+        finally:
+            if channel and channel.is_open:
+                channel.close()
+            if connection and connection.is_open:
+                connection.close()
+
+    def _publish_task(self, task: STTTask) -> None:
+        """Publish a task to the RabbitMQ queue with retry handling."""
+
+        payload = task.to_payload()
+        attempts = max(1, self.rabbitmq_config.publish_retries)
+        for attempt in range(1, attempts + 1):
+            connection: Optional[pika.BlockingConnection] = None
+            channel: Optional[BlockingChannel] = None
+            try:
+                connection = pika.BlockingConnection(self._connection_params)
+                channel = connection.channel()
+                channel.queue_declare(queue=self.rabbitmq_config.queue_name, durable=True)
+                channel.basic_publish(
+                    exchange="",
+                    routing_key=self.rabbitmq_config.queue_name,
+                    body=payload,
+                    properties=pika.BasicProperties(delivery_mode=2),
+                )
+                return
+            except AMQPConnectionError as exc:
+                self.logger.warning(
+                    "Failed to publish STT task for ticket_id=%s (attempt %d/%d): %s",
+                    task.ticket_id,
+                    attempt,
+                    attempts,
+                    exc,
+                )
+                if attempt < attempts:
+                    time.sleep(self.rabbitmq_config.reconnect_delay)
+            finally:
+                if channel and channel.is_open:
+                    channel.close()
+                if connection and connection.is_open:
+                    connection.close()
+        raise RuntimeError(
+            f"Unable to publish STT task for ticket_id={task.ticket_id} after {attempts} attempts"
+        )
+
+    def _run(self) -> None:
+        """Worker loop that consumes tasks from RabbitMQ."""
+
+        while not self._stop_event.is_set():
+            connection: Optional[pika.BlockingConnection] = None
+            channel: Optional[BlockingChannel] = None
+            try:
+                connection = pika.BlockingConnection(self._connection_params)
+                channel = connection.channel()
+                self._configure_channel(channel)
+                self.logger.info("STT queue worker connected to RabbitMQ")
+                self._consume(channel)
+            except AMQPConnectionError as exc:
+                if self._stop_event.is_set():
+                    break
+                self.logger.warning(
+                    "RabbitMQ connection lost: %s. Retrying in %.1f seconds",
+                    exc,
+                    self.rabbitmq_config.reconnect_delay,
+                )
+                time.sleep(self.rabbitmq_config.reconnect_delay)
+            except Exception:  # noqa: BLE001
+                if self._stop_event.is_set():
+                    break
+                self.logger.exception("Unexpected error in STT queue worker loop")
+                time.sleep(self.rabbitmq_config.reconnect_delay)
+            finally:
+                if channel and channel.is_open:
+                    channel.close()
+                if connection and connection.is_open:
+                    connection.close()
+
+    def _configure_channel(self, channel: BlockingChannel) -> None:
+        """Configure a channel for consumption."""
+
+        channel.queue_declare(queue=self.rabbitmq_config.queue_name, durable=True)
+        prefetch = max(1, self.rabbitmq_config.prefetch_count)
+        channel.basic_qos(prefetch_count=prefetch)
+
+    def _consume(self, channel: BlockingChannel) -> None:
+        """Consume tasks from RabbitMQ until stopped."""
+
+        while not self._stop_event.is_set():
+            method_frame, _properties, body = channel.basic_get(
+                queue=self.rabbitmq_config.queue_name,
+                auto_ack=False,
+            )
+            if method_frame is None:
+                time.sleep(0.5)
+                continue
+            try:
+                task = STTTask.from_payload(body)
+            except (KeyError, ValueError, TypeError) as exc:
+                self.logger.error("Discarding malformed STT task payload: %s", exc)
+                channel.basic_ack(method_frame.delivery_tag)
+                continue
+
+            success = False
+            try:
+                success = self._process_task(task)
+            except Exception:  # noqa: BLE001
+                self.logger.exception(
+                    "Unexpected error while processing STT task for ticket_id=%s",
+                    task.ticket_id,
+                )
+
+            if success:
+                channel.basic_ack(method_frame.delivery_tag)
+            else:
+                channel.basic_nack(
+                    method_frame.delivery_tag,
+                    requeue=self.rabbitmq_config.requeue_on_fail,
+                )
+
+    def _process_task(self, task: STTTask) -> bool:
+        """Attempt to deliver the task to the STT API with retries."""
+
+        if not task.wav_path.exists():
+            self.logger.error(
+                "STT task for ticket_id=%s failed; file missing at %s",
+                task.ticket_id,
+                task.wav_path,
+            )
+            return False
+
+        for attempt in range(1, self.stt_config.max_retries + 1):
+            try:
+                if self._send_request(task):
+                    return True
+            except FileNotFoundError:
+                self.logger.error(
+                    "STT task for ticket_id=%s failed; file missing at %s",
+                    task.ticket_id,
+                    task.wav_path,
+                )
+                return False
+            except RequestException as exc:
+                self.logger.warning(
+                    "STT request attempt %d for ticket_id=%s failed: %s",
+                    attempt,
+                    task.ticket_id,
+                    exc,
+                )
+            if attempt < self.stt_config.max_retries:
+                sleep_for = self.stt_config.retry_backoff * attempt
+                time.sleep(sleep_for)
+
+        self.logger.error(
+            "Exhausted retries for ticket_id=%s after %d attempts",
+            task.ticket_id,
+            self.stt_config.max_retries,
+        )
+        return False
+
+    def _send_request(self, task: STTTask) -> bool:
+        """Perform the HTTP request to the STT service."""
+
+        headers = self.stt_config.build_headers()
+        with task.wav_path.open("rb") as wav_file:
+            files = {
+                "file": (task.wav_path.name, wav_file, "audio/wav"),
+            }
+            data = {"ticket_id": task.ticket_id}
+            response = self.session.post(
+                self.stt_config.api_url,
+                headers=headers,
+                data=data,
+                files=files,
+                timeout=self.stt_config.timeout,
+            )
+        if response.ok:
+            self.logger.info(
+                "STT request for ticket_id=%s accepted with status %s",
+                task.ticket_id,
+                response.status_code,
+            )
+            return True
+        self.logger.error(
+            "STT API returned status %s for ticket_id=%s: %s",
+            response.status_code,
+            task.ticket_id,
+            response.text,
+        )
+        return False

--- a/src/datachain_etl/webhook.py
+++ b/src/datachain_etl/webhook.py
@@ -1,0 +1,43 @@
+"""FastAPI app that exposes a webhook for near real-time ETL."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .etl_core import ETLPipeline
+from .stt_queue import STTQueue
+
+
+class WebhookPayload(BaseModel):
+    """Payload describing the file that needs to be processed."""
+
+    ticket_id: str
+    file_path: str
+
+
+def create_app(pipeline: ETLPipeline, stt_queue: STTQueue | None = None) -> FastAPI:
+    """Create a configured FastAPI application."""
+
+    app = FastAPI(title="Datachain ETL Webhook")
+
+    if stt_queue is not None:
+        @app.on_event("startup")
+        async def start_queue() -> None:
+            stt_queue.start()
+
+        @app.on_event("shutdown")
+        async def stop_queue() -> None:
+            stt_queue.stop()
+
+    @app.post("/webhook")
+    async def ingest(payload: WebhookPayload) -> dict[str, str]:
+        try:
+            output = pipeline.process_single(payload.ticket_id, payload.file_path)
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        if stt_queue is not None:
+            stt_queue.enqueue(payload.ticket_id, output)
+        return {"status": "ok", "output_path": str(output)}
+
+    return app


### PR DESCRIPTION
## Summary
- add RabbitMQ configuration and dependency to drive the STT queue
- replace the in-memory STT worker with a RabbitMQ-backed publisher/consumer and wire it into the webhook service
- document the RabbitMQ environment variables required for near real-time processing
- provide a RabbitMQ + Management UI Docker Compose definition and setup guide for monitoring the queue

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cc55b92a38832db8cb0239ee51696f